### PR TITLE
More example tests and bug fixes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -253,13 +253,13 @@ func (c *rootConfigImpl) Source() Source {
 }
 
 func (c *rootConfigImpl) GetEntry(key string) Entry {
-	for _, config := range c.configs {
-		var val string
+	for i := len(c.configs) - 1; i >= 0; i-- {
+		val := ""
+		config := c.configs[i]
 		if found := config.TryGet(key, &val); found {
 			return newEntryImpl(key, val, config.Source())
 		}
 	}
-
 	return newEntryImpl(key, "", nil)
 }
 

--- a/pkg/config/example_config_env_var_prefix_test.go
+++ b/pkg/config/example_config_env_var_prefix_test.go
@@ -1,0 +1,41 @@
+package config_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ppanyukov/aspnet-go/pkg/config"
+)
+
+func Example_envVarsPrefix() {
+	// In ASP.NET Environment Variables provider you can specify a prefix.
+	// In such case only env vars with specified prefix are loaded. The prefix
+	// is also stripped away from the key. This behaviour is preserved here.
+	const prefix = "MYAPP_"
+
+	env := map[string]string{
+		// These will be included and the prefix will be stripped from key names.
+		"MYAPP_SETTING_A": "A",
+		"MYAPP_SETTING_B": "B",
+
+		// These will be excluded
+		"OTHERAPP_SETTING_A": "A",
+		"OTHERAPP_SETTING_B": "A",
+	}
+
+	builder := config.NewBuilder()
+	builder.AddSource(config.NewEnvVarsMapSource(prefix, env))
+	c, err := builder.Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, key := range c.Keys() {
+		val := c.Get(key)
+		fmt.Printf("key=%s, value=%s\n", key, val)
+	}
+
+	// Output:
+	// key=setting_a, value=A
+	// key=setting_b, value=B
+}

--- a/pkg/config/example_config_key_hierarchy_test.go
+++ b/pkg/config/example_config_key_hierarchy_test.go
@@ -1,0 +1,56 @@
+package config_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ppanyukov/aspnet-go/pkg/config"
+)
+
+func Example_keyHierarchy() {
+	// ASP.NET config supports hierarchical keys, especially when it comes to Json.
+	// Env vars also have this support using a special double underscore "__"
+	// as a separator.
+
+	// Consider a Json config file like this.
+	json := `
+	{
+		// Since ASP.NET config allows comments in JSON file so do we.
+		"MyApp": {
+			"Logging": {
+				// This will be under "myapp:logging:enabled" key.
+				// The value will be a string, not a bool.
+				"Enabled": true,
+
+				// This will be under "myapp:logging:level" key
+				"Level": "info"
+			}
+		}
+	}
+	`
+
+	// We can override Json config with env vars like so.
+	// Note that the casing of keys doesn't matter.
+	env := map[string]string{
+		// This also will be under "myapp:logging:level" key
+		// and will override the setting in json file.
+		"MYAPP__LOGGING__level": "debug",
+	}
+
+	builder := config.NewBuilder()
+	builder.AddSource(config.NewJsonSource([]byte(json)).WithName("json file"))
+	builder.AddSource(config.NewEnvVarsMapSource("", env).WithName("env vars"))
+	c, err := builder.Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, key := range c.Keys() {
+		entry := c.GetEntry(key)
+		fmt.Printf("key=%s, value=%s, source=%s\n", key, entry.Value(), entry.Source().Name())
+	}
+
+	// Output:
+	// key=myapp:logging:enabled, value=true, source=json file
+	// key=myapp:logging:level, value=debug, source=env vars
+}

--- a/pkg/config/json_source.go
+++ b/pkg/config/json_source.go
@@ -37,7 +37,7 @@ func (s *jsonSource) Build() (Config, error) {
 	r := bytes.NewBuffer(s.json)
 	m, err := parser.Load(r)
 	if err != nil {
-		return nil, errors.Errorf("%s: %v", s.name, err)
+		return nil, errors.Errorf("jsonSource: %s: %v", s.name, err)
 	}
 
 	return newConfigImpl(s, m), nil


### PR DESCRIPTION
* More example tests (which caught the bug)
* Bug fix with `RootConfig.GetEntry()`
* Simpler code for `RootCofig` with less repetition.
* Better error message when parsing JSON
